### PR TITLE
fix: Use `clarity` as extension ID

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,4 +1,4 @@
-id = "clarity-lsp"
+id = "clarity"
 name = "Clarity"
 version = "0.0.1"
 schema_version = 1


### PR DESCRIPTION
Use `id` in `extension.toml` which matches the `id` used in the PR zed-industries/extensions#2764